### PR TITLE
Default expand/collapse icon orientations

### DIFF
--- a/expansionpanel/src/main/java/com/github/florent37/expansionpanel/ExpansionHeader.java
+++ b/expansionpanel/src/main/java/com/github/florent37/expansionpanel/ExpansionHeader.java
@@ -26,8 +26,8 @@ public class ExpansionHeader extends FrameLayout {
     ExpansionLayout expansionLayout;
     @Nullable
     Animator indicatorAnimator;
-    private int headerRotationExpanded = 90;
-    private int headerRotationCollapsed = 0;
+    private int headerRotationExpanded = 270;
+    private int headerRotationCollapsed = 90;
     private boolean expansionLayoutInitialised = false;
 
     public ExpansionHeader(@NonNull Context context) {


### PR DESCRIPTION
Default expand and collapse orientations should be the same as described in the material design specs.
- Collapsed: `v` (bottom)
- Expanded: `^` (top)

Sidenote ;)
> Don't use right-pointing carets on line items

https://developer.android.com/design/patterns/pure-android.html